### PR TITLE
fix dependency version conflict

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,12 +15,13 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <dubbo.version>2.8.4</dubbo.version>
-        <spring.version>4.1.6.RELEASE</spring.version>
+        <!--<spring.version>4.1.6.RELEASE</spring.version>-->
+        <spring.version>3.2.9.RELEASE</spring.version>
         <zookeeper.version>3.4.6</zookeeper.version>
         <zkclient.version>0.1</zkclient.version>
         <curator.version>2.5.0</curator.version>
         <servlet.version>2.5</servlet.version>
-        <jetbrick-template.version>2.0.10</jetbrick-template.version>
+        <jetbrick-template.version>2.0</jetbrick-template.version>
         <mybatis.version>3.2.7</mybatis.version>
         <mybatis-spring.version>1.2.2</mybatis-spring.version>
         <mysql.version>5.1.30</mysql.version>
@@ -224,12 +225,12 @@
         <dependency>
             <groupId>org.springframework.security</groupId>
             <artifactId>spring-security-web</artifactId>
-            <version>3.2.8.RELEASE</version>
+            <version>3.2.9.RELEASE</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.security</groupId>
             <artifactId>spring-security-config</artifactId>
-            <version>3.2.8.RELEASE</version>
+            <version>3.2.9.RELEASE</version>
         </dependency>
         <dependency>
             <groupId>org.apache.zookeeper</groupId>
@@ -252,6 +253,12 @@
             <groupId>com.github.subchen</groupId>
             <artifactId>jetbrick-template-springmvc</artifactId>
             <version>${jetbrick-template.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.springframework</groupId>
+                    <artifactId>spring-webmvc</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <!-- MyBatis -->
         <dependency>


### PR DESCRIPTION
引用了不同版本的Spring系列包，运行时会出错，此处将它们都改为3.2.9.RELEASE

原本包含了三个版本：
3.2.8.RELEASE
3.2.9.RELEASE
4.1.6.RELEASE

3.2.8与3.2.9应该没什么冲突，但是3.X与4.X肯定是不兼容的。运行时报ClassNotFoundException